### PR TITLE
JMC-6455 - Attach source JARs to the project

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,19 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.0.1</version>
 				<executions>


### PR DESCRIPTION
It would be really helpful to have source JARs for your modules. This will provide much better IDE support (code completion, access to documentation, ...) when using the modules as third-party libraries.
With the adjustments of this PR Maven will create a source JAR for each module in the `core/` directory and install/deploy it to the Maven repository.
Furthermore, if you are planning to publish the mission control JARs on Maven Central, you need to provide source (and Javadoc) JARs along with the binaries.
