### PR TITLE
Provide simple mechanism for building JMC under Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ workspace/
 
 # Ignore MacOS X finder files
 .DS_Store
+
+# Useful for local m2 cache when docker building
+.m2

--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ The above will not run StacktraceModelTest, as that is also matched by "test.exc
 
 Note that if UI-tests are supposed to be part of the filtered run the "uitests" profile needs to be specified as well. Otherwise the UI won't start up and so the tests fail.
 
+
+## Building using docker and docker-compose
+
+```
+docker-compose -f docker/docker-compose.yml run jmc
+```
+
+Once build has finished the results will be in the `target` directory
+
 ## Running the Locally Built JMC
 The built JMC will end up in the `target` folder in the root. To run it, go to `target/products/org.openjdk.jmc/<platform>` to find the launcher. Don't forget to override the vm flag with the JVM you wish to use for running JMC.
 

--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,0 +1,14 @@
+FROM openjdk:11.0.2-jdk-stretch AS builder
+
+RUN apt-get update && apt-get install -y maven
+
+WORKDIR /jmc
+COPY core core/
+COPY application application/
+COPY configuration configuration/
+COPY releng releng/
+COPY pom.xml ./
+RUN grep -rl localhost:8080 releng | xargs sed -i s/localhost:8080/p2:8080/
+ENV MAVEN_OPTS="-Xmx1G"
+
+CMD cd /jmc/core && mvn clean install && cd /jmc && mvn package && cp -a /jmc/target/* /target

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.2-jdk-stretch
+
+
+RUN apt-get update && apt-get install -y maven
+
+COPY releng /jmc/releng/
+
+WORKDIR /jmc/releng/third-party
+RUN mvn p2:site
+CMD mvn jetty:run

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  p2:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile-p2
+    ports:
+      - "8080:8080"
+  jmc:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile-jmc
+    depends_on:
+      - start_dependencies
+    volumes:
+      - ../.m2:/root/.m2
+      - ../target/:/target
+  start_dependencies:
+    image: alpine:3.9
+    depends_on:
+      - p2
+    command: >
+      /bin/ash -c "
+      apk update && apk add curl;
+      while ! curl http://p2:8080/site/;
+        do
+          echo sleeping;
+          sleep 1;
+        done;
+        echo Connected!;
+      "


### PR DESCRIPTION
Use docker-compose to create appropriate containers for
following the build instructions, and put the result in
the target directory.

Instructions are provided